### PR TITLE
Fix SYNOPSIS, missed set_tab_title() import

### DIFF
--- a/lib/Term/Title.pm
+++ b/lib/Term/Title.pm
@@ -89,7 +89,7 @@ __END__
 
 =head1 SYNOPSIS
 
-    use Term::Title 'set_titlebar';
+    use Term::Title 'set_titlebar', 'set_tab_title';
 
     set_titlebar("This goes into the title");
 


### PR DESCRIPTION
A quick fix. Just noticed the SYNOPSIS is missing the import of the set_tab_title()
